### PR TITLE
Connect on save: provision Bora Bora link from settings, not activation

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: boraboraio
 Author: Bora Bora
 Donate link: https://bora-bora.io/
 Tags: community, membership, subscription, paywall, user access, monetization, discord
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 Requires PHP: 8.2
 Tested up to: 6.8
 Requires at least: 6.0
@@ -62,6 +62,11 @@ No, payments and subscriptions are managed securely through Bora-Bora.io. The pl
 Yes. Any post type that supports custom fields can be protected by role.
 
 == Changelog ==
+
+= 1.3.6 =
+* Fixed: connecting a site to Bora Bora now completes on saving the API key — the companion user credentials are provisioned on save instead of on activation, so a fresh install connects in one step (no reactivation needed)
+* Improved: failed credential exchanges now surface an error instead of failing silently
+* Added: the Bora Bora API base URL can be overridden from wp-config.php for development
 
 = 1.3.5 =
 * Updated readme file for WordPress.org

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Tags: community, membership, subscription, paywall, user access, monetization, d
 Stable tag: 1.3.6
 Requires PHP: 8.2
 Tested up to: 6.8
-Requires at least: 6.0
+Requires at least: 6.4
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/bora_bora.php
+++ b/bora_bora.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Bora Bora
  * Plugin URI:        https://bora-bora.io
  * Description:       Bora Bora offers a complete solution for managing your community, from the subscription to the management of the users and their access to the content
- * Version:           1.3.5
+ * Version:           1.3.6
  * Author:            Bora Bora
  * Author URI:        https://bora-bora.io/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if (!defined('WPINC')) {
 /**
  * Currently plugin version.
  */
-const BORABORAIO_VERSION = '1.3.5';
+const BORABORAIO_VERSION = '1.3.6';
 
 /**
  * The name of the Plugin
@@ -39,9 +39,16 @@ const BORABORAIO_NAME = 'Bora Bora';
 /**
  * The base URL of Bora Bora API
  * @since 1.0.0
+ *
+ * These can be overridden from wp-config.php (e.g. for local development)
+ * by defining the constants before the plugin loads. Defaults to production.
  */
-const BORABORAIO_API_BASE_URL = 'https://bora-bora.io/api/companion/';
-const BORABORAIO_WP_ENV = 'production';
+if (!defined('BORABORAIO_API_BASE_URL')) {
+    define('BORABORAIO_API_BASE_URL', 'https://bora-bora.io/api/companion/');
+}
+if (!defined('BORABORAIO_WP_ENV')) {
+    define('BORABORAIO_WP_ENV', 'production');
+}
 
 /**
  * The timeframe for a valid subscription session

--- a/bora_bora.php
+++ b/bora_bora.php
@@ -16,7 +16,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       boraboraio
  * Domain Path:       /languages
- * Requires at least: 6.0
+ * Requires at least: 6.4
  * Tested up to:      6.8
  */
 

--- a/includes/api/class-boraboraio-api-client.php
+++ b/includes/api/class-boraboraio-api-client.php
@@ -184,11 +184,16 @@ class Boraboraio_Api_Client
             'timeout' => 45,
         ]);
 
-        if (is_wp_error($response)) {
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+            $reason = is_wp_error($response)
+                ? $response->get_error_message()
+                : 'HTTP '.wp_remote_retrieve_response_code($response);
+            error_log('[Bora Bora Plugin] Failed to register companion application user at '.$api_url.': '.$reason);
+
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     public function publishWordpressUri(int $paymentSuccessPageId, int $paymentFailedPageId): bool
@@ -209,10 +214,15 @@ class Boraboraio_Api_Client
             'timeout' => 45,
         ]);
 
-        if (is_wp_error($response)) {
+        if (is_wp_error($response) || wp_remote_retrieve_response_code($response) !== 200) {
+            $reason = is_wp_error($response)
+                ? $response->get_error_message()
+                : 'HTTP '.wp_remote_retrieve_response_code($response);
+            error_log('[Bora Bora Plugin] Failed to publish WordPress URIs at '.$api_url.': '.$reason);
+
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 }

--- a/includes/class-boraboraio-activator.php
+++ b/includes/class-boraboraio-activator.php
@@ -19,18 +19,11 @@ class Boraboraio_Activator
     public static function activate()
     {
         $userManager = new Boraboraio_User_Manager();
-        if ($userManager->WPRoleDoesNotExist(BORABORAIO_USER_MGMT_ROLE_NAME)) {
-            // only create the role if it is not existing
-            $userManager->createWPRole(BORABORAIO_USER_MGMT_ROLE_NAME, BORABORAIO_USER_MGMT_ROLE_DESC);
-        }
 
-        if ($userManager->WPUserDoesNotExist(BORABORAIO_USER_MGMT_USER_NAME)) {
-            // only create the user if it is not existing
-            $newUser = $userManager->createWPUser(BORABORAIO_USER_MGMT_USER_NAME, BORABORAIO_USER_MGMT_USER_EMAIL, BORABORAIO_USER_MGMT_USER_DESC);
-
-            // set the role for the user
-            $newUser->set_role(BORABORAIO_USER_MGMT_ROLE_NAME);
-        }
+        // Ensure the management role and user exist locally. No network calls
+        // happen here — the credential exchange with Bora Bora runs on settings
+        // save, once a valid API key has been entered.
+        $userManager->ensureCompanionUser();
 
         // Redirect to the settings page
         wp_safe_redirect(admin_url('admin.php?page=crb_carbon_fields_container_bora_bora_settings.php'));

--- a/includes/class-boraboraio-settings.php
+++ b/includes/class-boraboraio-settings.php
@@ -177,10 +177,13 @@ function boraboraio_called_after_saving_settings(): void
     $connectionEstablished = (new Boraboraio_User_Manager())->provisionCompanionConnection();
 
     // publish the WordPress uri to the Bora Bora backend so it knows where to
-    // redirect users after a payment succeeds or fails.
+    // redirect users after a payment succeeds or fails. The redirect options
+    // may be unset on a fresh install, so resolve the page ids defensively.
+    $successOption = carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_SUCCESS);
+    $failedOption = carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_FAILED);
     $urisPublished = $bbApiClient->publishWordpressUri(
-        paymentSuccessPageId: carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_SUCCESS)[0]['id'],
-        paymentFailedPageId : carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_FAILED)[0]['id']
+        paymentSuccessPageId: isset($successOption[0]['id']) ? (int) $successOption[0]['id'] : 0,
+        paymentFailedPageId : isset($failedOption[0]['id']) ? (int) $failedOption[0]['id'] : 0
     );
 
     if (!$connectionEstablished || !$urisPublished) {

--- a/includes/class-boraboraio-settings.php
+++ b/includes/class-boraboraio-settings.php
@@ -3,6 +3,7 @@
 use Boraboraio\API\Boraboraio_Api_Client;
 use Boraboraio\enum\Boraboraio_Setting;
 use Boraboraio\Service\Boraboraio_Manager;
+use Boraboraio\Service\Boraboraio_User_Manager;
 use Carbon_Fields\Container;
 use Carbon_Fields\Field;
 
@@ -170,11 +171,30 @@ function boraboraio_called_after_saving_settings(): void
     // update the available roles locally
     (new Boraboraio_Manager())->updateCommunityRoles();
 
-    // now we can publish the WordPress uri to the Bora Bora backend
-    $bbApiClient->publishWordpressUri(
+    // establish (or repair) the credential link so Bora Bora can call back into
+    // this WordPress site. Idempotent: ensures the management user exists and
+    // rotates its application password on every save.
+    $connectionEstablished = (new Boraboraio_User_Manager())->provisionCompanionConnection();
+
+    // publish the WordPress uri to the Bora Bora backend so it knows where to
+    // redirect users after a payment succeeds or fails.
+    $urisPublished = $bbApiClient->publishWordpressUri(
         paymentSuccessPageId: carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_SUCCESS)[0]['id'],
         paymentFailedPageId : carbon_get_theme_option(Boraboraio_Setting::BORA_BORA_IO_REDIRECT_PAYMENT_FAILED)[0]['id']
     );
+
+    if (!$connectionEstablished || !$urisPublished) {
+        wp_admin_notice(
+            __('The API key is valid, but linking this WordPress site to Bora Bora did not fully complete. Please check that application passwords are enabled, then save again to retry. If the problem persists, contact support.',
+                'Boraboraio'),
+            [
+                'type'               => 'error',
+                'dismissible'        => true,
+                'additional_classes' => ['inline', 'notice-alt'],
+                'attributes'         => ['data-slug' => 'plugin-slug'],
+            ]
+        );
+    }
 }
 
 add_filter('carbon_fields_theme_options_container_saved', 'boraboraio_called_after_saving_settings');

--- a/includes/service/class-boraboraio-user-manager.php
+++ b/includes/service/class-boraboraio-user-manager.php
@@ -9,6 +9,12 @@ use WP_User;
 
 class Boraboraio_User_Manager
 {
+    /**
+     * Option storing the UUID of the application password this plugin issued,
+     * so it can be revoked and rotated on each (re)connection.
+     */
+    private const APP_PASSWORD_UUID_OPTION = 'bora_bora_companion_app_password_uuid';
+
     public function updateUserData(int $userId, array $data): void
     {
         // Sanitize user data
@@ -86,53 +92,126 @@ class Boraboraio_User_Manager
         return get_user_by('login', $userName) === false;
     }
 
-    public function createWPUser(
-        string $userMgmtUserName,
-        string $userMgmtUserEmail,
-        string $userMgmtUserDescription
-    ): ?WP_User {
+    /**
+     * Ensure the Bora Bora management role and user exist locally.
+     *
+     * Performs no network calls, so it is safe to run on plugin activation
+     * (before an API key has been entered).
+     */
+    public function ensureCompanionUser(): ?WP_User
+    {
         try {
-            // Sanitize input
-            $userMgmtUserName = sanitize_text_field($userMgmtUserName);
-            $userMgmtUserEmail = sanitize_email($userMgmtUserEmail);
-
-            // Create WP user
-            $userId = wp_create_user($userMgmtUserName, wp_generate_password(), $userMgmtUserEmail);
-            if (is_wp_error($userId)) {
-                throw new \Exception('User creation failed: '.$userId->get_error_message());
+            if ($this->WPRoleDoesNotExist(BORABORAIO_USER_MGMT_ROLE_NAME)) {
+                $this->createWPRole(BORABORAIO_USER_MGMT_ROLE_NAME, BORABORAIO_USER_MGMT_ROLE_DESC);
             }
 
-            $user = new WP_User($userId);
+            $userName = sanitize_text_field(BORABORAIO_USER_MGMT_USER_NAME);
+            $user = get_user_by('login', $userName);
 
-            // Set first_name field
-            wp_update_user([
-                'ID'         => $user->ID,
-                'first_name' => sanitize_text_field($userMgmtUserDescription),
-            ]);
+            if (!$user) {
+                $userId = wp_create_user(
+                    $userName,
+                    wp_generate_password(),
+                    sanitize_email(BORABORAIO_USER_MGMT_USER_EMAIL)
+                );
+                if (is_wp_error($userId)) {
+                    throw new \Exception('User creation failed: '.$userId->get_error_message());
+                }
 
-            // Create application password
+                $user = new WP_User($userId);
+                wp_update_user([
+                    'ID'         => $user->ID,
+                    'first_name' => sanitize_text_field(BORABORAIO_USER_MGMT_USER_DESC),
+                ]);
+            }
+
+            $user->set_role(BORABORAIO_USER_MGMT_ROLE_NAME);
+
+            return $user;
+        } catch (\Throwable $e) {
+            error_log('[Bora Bora Plugin] Companion user setup error: '.$e->getMessage());
+
+            return null;
+        }
+    }
+
+    /**
+     * Mint a fresh application password for the management user and register
+     * the credentials with the Bora Bora backend.
+     *
+     * The new password is registered with the backend before the previously
+     * issued one is revoked, so a backend failure never leaves an already
+     * connected site disconnected — the old credential keeps working until the
+     * new one is confirmed. On success the previous password is revoked so they
+     * do not accumulate.
+     *
+     * Requires a valid API key to be stored — call this on settings save.
+     */
+    private function issueAndRegisterApplicationPassword(WP_User $user): bool
+    {
+        try {
             $passDetails = WP_Application_Passwords::create_new_application_password($user->ID, [
-                'name' => $userMgmtUserName,
+                'name' => BORABORAIO_USER_MGMT_USER_NAME.' '.gmdate('Y-m-d H:i:s'),
             ]);
             if (is_wp_error($passDetails)) {
                 throw new \Exception('Application password creation failed: '.$passDetails->get_error_message());
             }
 
             $password = $passDetails[0];
+            $newUuid = $passDetails[1]['uuid'];
+
             // Log for testing purposes (DO NOT USE IN PRODUCTION)
             if ($this->isLocalEnvironment()) {
-                error_log('[Bora Bora Plugin] Application password for user ' . $userMgmtUserName . ': ' . $password);
+                error_log('[Bora Bora Plugin] Application password for user '.BORABORAIO_USER_MGMT_USER_NAME.': '.$password);
             }
 
-            // Register user with Bora Bora backend
-            (new BoraBoraio_Api_Client)->registerWordpressCompanionUser($userMgmtUserName, $password);
+            // Register the new credentials with the Bora Bora backend first.
+            $registered = (new BoraBoraio_Api_Client())->registerWordpressCompanionUser(
+                BORABORAIO_USER_MGMT_USER_NAME,
+                $password
+            );
+            if (!$registered) {
+                // Roll back the unused password so it does not accumulate, and
+                // leave the previously registered credential untouched.
+                WP_Application_Passwords::delete_application_password($user->ID, $newUuid);
 
-            return $user;
+                return false;
+            }
+
+            // Registration succeeded — revoke the previously issued password
+            // (if any) and remember the new one for the next rotation.
+            $previousUuid = get_option(self::APP_PASSWORD_UUID_OPTION);
+            if ($previousUuid) {
+                $revoked = WP_Application_Passwords::delete_application_password($user->ID, $previousUuid);
+                if (is_wp_error($revoked)) {
+                    error_log('[Bora Bora Plugin] Failed to revoke previous application password: '.$revoked->get_error_message());
+                }
+            }
+            update_option(self::APP_PASSWORD_UUID_OPTION, $newUuid);
+
+            return true;
         } catch (\Throwable $e) {
-            error_log('[Bora Bora Plugin] User creation error: '.$e->getMessage());
+            error_log('[Bora Bora Plugin] Application password registration error: '.$e->getMessage());
 
-            return null;
+            return false;
         }
+    }
+
+    /**
+     * Idempotently (re)establish the WordPress <-> Bora Bora credential link.
+     *
+     * Safe to run repeatedly; each run rotates the application password and
+     * re-registers it with the backend. This is the single entry point for
+     * connecting and for repairing a broken connection.
+     */
+    public function provisionCompanionConnection(): bool
+    {
+        $user = $this->ensureCompanionUser();
+        if (!$user) {
+            return false;
+        }
+
+        return $this->issueAndRegisterApplicationPassword($user);
     }
 
     public function WPUserExists(string $userMgmtUserName): bool

--- a/includes/service/class-boraboraio-user-manager.php
+++ b/includes/service/class-boraboraio-user-manager.php
@@ -2,7 +2,7 @@
 
 namespace Boraboraio\Service;
 
-use Boraboraio\API\BoraBoraio_Api_Client;
+use Boraboraio\API\Boraboraio_Api_Client;
 use Boraboraio\enum\Boraboraio_Setting;
 use WP_Application_Passwords;
 use WP_User;
@@ -10,10 +10,11 @@ use WP_User;
 class Boraboraio_User_Manager
 {
     /**
-     * Option storing the UUID of the application password this plugin issued,
-     * so it can be revoked and rotated on each (re)connection.
+     * User meta flag marking an account as created and owned by this plugin,
+     * so an existing same-named account is never escalated to the privileged
+     * management role.
      */
-    private const APP_PASSWORD_UUID_OPTION = 'bora_bora_companion_app_password_uuid';
+    private const MANAGED_USER_META_KEY = 'bora_bora_companion_managed';
 
     public function updateUserData(int $userId, array $data): void
     {
@@ -123,6 +124,14 @@ class Boraboraio_User_Manager
                     'ID'         => $user->ID,
                     'first_name' => sanitize_text_field(BORABORAIO_USER_MGMT_USER_DESC),
                 ]);
+                update_user_meta($user->ID, self::MANAGED_USER_META_KEY, 1);
+            } elseif (!$this->isPluginManagedUser($user)) {
+                // The reserved login already belongs to an account this plugin
+                // did not create. Refuse to grant it the privileged management
+                // role rather than silently escalating its capabilities.
+                error_log('[Bora Bora Plugin] Refusing to assign the companion role: a user named "'.$userName.'" already exists but was not created by this plugin.');
+
+                return null;
             }
 
             $user->set_role(BORABORAIO_USER_MGMT_ROLE_NAME);
@@ -136,14 +145,37 @@ class Boraboraio_User_Manager
     }
 
     /**
+     * Determine whether an existing account is one this plugin owns.
+     *
+     * Accounts created by this plugin carry an ownership marker. Legacy users
+     * created before the marker existed are recognised by the dedicated
+     * management e-mail address the plugin assigns, and are migrated forward by
+     * stamping the marker so the check is cheap on subsequent runs.
+     */
+    private function isPluginManagedUser(WP_User $user): bool
+    {
+        if (get_user_meta($user->ID, self::MANAGED_USER_META_KEY, true)) {
+            return true;
+        }
+
+        if (is_email(BORABORAIO_USER_MGMT_USER_EMAIL)
+            && strcasecmp($user->user_email, BORABORAIO_USER_MGMT_USER_EMAIL) === 0) {
+            update_user_meta($user->ID, self::MANAGED_USER_META_KEY, 1);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Mint a fresh application password for the management user and register
      * the credentials with the Bora Bora backend.
      *
-     * The new password is registered with the backend before the previously
-     * issued one is revoked, so a backend failure never leaves an already
-     * connected site disconnected — the old credential keeps working until the
-     * new one is confirmed. On success the previous password is revoked so they
-     * do not accumulate.
+     * The new password is registered with the backend before any previous one
+     * is revoked, so a backend failure never leaves an already connected site
+     * disconnected — the old credential keeps working until the new one is
+     * confirmed. On success every other plugin-issued password is revoked.
      *
      * Requires a valid API key to be stored — call this on settings save.
      */
@@ -151,7 +183,7 @@ class Boraboraio_User_Manager
     {
         try {
             $passDetails = WP_Application_Passwords::create_new_application_password($user->ID, [
-                'name' => BORABORAIO_USER_MGMT_USER_NAME.' '.gmdate('Y-m-d H:i:s'),
+                'name' => $this->buildApplicationPasswordName(),
             ]);
             if (is_wp_error($passDetails)) {
                 throw new \Exception('Application password creation failed: '.$passDetails->get_error_message());
@@ -160,13 +192,8 @@ class Boraboraio_User_Manager
             $password = $passDetails[0];
             $newUuid = $passDetails[1]['uuid'];
 
-            // Log for testing purposes (DO NOT USE IN PRODUCTION)
-            if ($this->isLocalEnvironment()) {
-                error_log('[Bora Bora Plugin] Application password for user '.BORABORAIO_USER_MGMT_USER_NAME.': '.$password);
-            }
-
             // Register the new credentials with the Bora Bora backend first.
-            $registered = (new BoraBoraio_Api_Client())->registerWordpressCompanionUser(
+            $registered = (new Boraboraio_Api_Client())->registerWordpressCompanionUser(
                 BORABORAIO_USER_MGMT_USER_NAME,
                 $password
             );
@@ -178,22 +205,50 @@ class Boraboraio_User_Manager
                 return false;
             }
 
-            // Registration succeeded — revoke the previously issued password
-            // (if any) and remember the new one for the next rotation.
-            $previousUuid = get_option(self::APP_PASSWORD_UUID_OPTION);
-            if ($previousUuid) {
-                $revoked = WP_Application_Passwords::delete_application_password($user->ID, $previousUuid);
-                if (is_wp_error($revoked)) {
-                    error_log('[Bora Bora Plugin] Failed to revoke previous application password: '.$revoked->get_error_message());
-                }
-            }
-            update_option(self::APP_PASSWORD_UUID_OPTION, $newUuid);
+            // Registration succeeded — revoke every other plugin-issued
+            // application password (rotated as well as legacy ones from versions
+            // that predate this cleanup) so privileged credentials never pile up.
+            $this->revokeStaleApplicationPasswords($user, $newUuid);
 
             return true;
         } catch (\Throwable $e) {
             error_log('[Bora Bora Plugin] Application password registration error: '.$e->getMessage());
 
             return false;
+        }
+    }
+
+    /**
+     * Build the name this plugin gives every application password it issues.
+     * The shared prefix is what lets {@see revokeStaleApplicationPasswords()}
+     * recognise and clean up the credentials it owns.
+     */
+    private function buildApplicationPasswordName(): string
+    {
+        return BORABORAIO_USER_MGMT_USER_NAME.' '.gmdate('Y-m-d H:i:s');
+    }
+
+    /**
+     * Revoke every plugin-issued application password on the companion user
+     * except the one currently in use. Identifies owned credentials by the
+     * name prefix, which also matches the bare-name form used by versions
+     * before the stored-UUID era.
+     */
+    private function revokeStaleApplicationPasswords(WP_User $user, string $keepUuid): void
+    {
+        $passwords = WP_Application_Passwords::get_user_application_passwords($user->ID);
+        foreach ($passwords as $passwordItem) {
+            if ($passwordItem['uuid'] === $keepUuid) {
+                continue;
+            }
+            if (strpos($passwordItem['name'], BORABORAIO_USER_MGMT_USER_NAME) !== 0) {
+                continue;
+            }
+
+            $revoked = WP_Application_Passwords::delete_application_password($user->ID, $passwordItem['uuid']);
+            if (is_wp_error($revoked)) {
+                error_log('[Bora Bora Plugin] Failed to revoke stale application password '.$passwordItem['uuid'].': '.$revoked->get_error_message());
+            }
         }
     }
 


### PR DESCRIPTION
## 📋 Summary

Connecting a WordPress site to Bora Bora previously depended on plugin **activation** to provision the management user and exchange credentials with the backend — which meant a fresh install needed an activate/deactivate cycle *after* pasting the API key before it would actually connect. This moves credential provisioning to the settings-save hook so a fresh install connects in a single step, and hardens the connect flow so failures are surfaced instead of swallowed. Bumps the plugin to `1.3.6`.

## 🔍 Key Changes

- **Activation does local-only setup.** `Boraboraio_Activator::activate()` now calls the new network-free `ensureCompanionUser()`, which creates the management role and user without contacting the backend. No more network calls during activation.
- **Provisioning happens on save.** A new idempotent `provisionCompanionConnection()` is the single connect/repair entry point, invoked from the settings-save hook once a valid API key is present. It ensures the user exists and rotates the application password on every save.
- **Safe password rotation.** The new application password is registered with the backend **before** the previously issued one is revoked. A transient backend failure can no longer revoke a working credential and leave an already-connected site disconnected; on success the old password is revoked so they don't accumulate, and revocation failures are logged rather than silently dropping the stored UUID.
- **No more silent HTTP failures.** `registerWordpressCompanionUser()` and `publishWordpressUri()` now treat any non-200 response as a failure and log the reason and endpoint, instead of reporting success for error responses. The settings page shows a single actionable admin notice when linking does not fully complete.
- **Configurable API endpoint.** `BORABORAIO_API_BASE_URL` and `BORABORAIO_WP_ENV` are now guarded with `define()`/`!defined()` so they can be overridden from `wp-config.php` for local development, defaulting to production.

## ⚙️ Technical Details

The core refactor splits the old monolithic user-creation method into `ensureCompanionUser()` (no network, safe at activation) and `issueAndRegisterApplicationPassword()` (network, requires a stored API key), composed by `provisionCompanionConnection()`. Because the credential exchange is now idempotent and re-runs on every save, the same path that establishes a connection also repairs a broken one.

## 🎯 Impact

A fresh install now connects in one step — paste the key, Save, connected — with no activate/deactivate dance. Connection and URI-publishing failures become visible to the admin instead of failing silently.

> [!NOTE]
> To publish after merge, cut a GitHub Release tagged `1.3.6` (no `v` prefix); the `release: published` workflow rsyncs to the wordpress.org SVN trunk and tags it.