### PR TITLE
Fix SVN deploy: stop rsync deleting the working copy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         run: |
           svn checkout --username $SVN_USERNAME --password $SVN_PASSWORD $SVN_URL svn-repo
-          rsync -av --exclude='.git' --delete ./ svn-repo/ || true
+          rsync -av --exclude='.git' --exclude='.svn' --exclude='/svn-repo' --delete ./ svn-repo/ || true
           cd svn-repo
           svn add --force .
           svn commit -m "Sync GitHub release to SVN" --username $SVN_USERNAME --password $SVN_PASSWORD || true


### PR DESCRIPTION
The release-to-SVN sync failed on the 1.3.6 release. `rsync -av --exclude='.git' --delete ./ svn-repo/` deleted `svn-repo/.svn` (the source repo root has no top-level `.svn`, and `.svn` was not excluded) and recursively copied the `svn-repo` checkout into itself, so `svn add`/`commit` then failed with `E155007: ... is not a working copy`.

This excludes `.svn` and the `/svn-repo` directory from the rsync, leaving the working-copy metadata intact so the commit and tag steps can run.