### PR TITLE
Fix WordPress.org deploy: use 10up action + clean up SVN

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,11 @@
+# Files and directories that should NOT be deployed to WordPress.org.
+# The 10up deploy action rsyncs everything except these into SVN trunk.
+
+/.git
+/.github
+/.gitignore
+/.distignore
+/deploy.sh
+/generate-wp-icons.sh
+/composer.json
+/composer.lock

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,37 +1,20 @@
-name: Sync to SVN on Release
+name: Deploy to WordPress.org
 
 on:
   release:
     types: [published]
 
 jobs:
-  sync-to-svn:
+  deploy:
+    name: Deploy plugin to WordPress.org SVN
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Set up SVN
-        run: sudo apt-get install subversion
-
-      - name: Sync repository to SVN
+      - name: WordPress Plugin Deploy
+        uses: 10up/action-wordpress-plugin-deploy@stable
         env:
-          SVN_URL: ${{ secrets.SVN_URL }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        run: |
-          svn checkout --username $SVN_USERNAME --password $SVN_PASSWORD $SVN_URL svn-repo
-          rsync -av --exclude='.git' --exclude='.svn' --exclude='/svn-repo' --delete ./ svn-repo/ || true
-          cd svn-repo
-          svn add --force .
-          svn commit -m "Sync GitHub release to SVN" --username $SVN_USERNAME --password $SVN_PASSWORD || true
-
-      - name: Tag SVN with release tag
-        env:
-          SVN_URL: ${{ secrets.SVN_URL }}
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          svn copy --username $SVN_USERNAME --password $SVN_PASSWORD $SVN_URL/trunk $SVN_URL/tags/$RELEASE_TAG -m "Tagging release $RELEASE_TAG"
+          SLUG: bora-bora

--- a/.github/workflows/svn-cleanup.yml
+++ b/.github/workflows/svn-cleanup.yml
@@ -1,0 +1,38 @@
+name: SVN cleanup (one-off)
+
+# Manually-triggered, one-off cleanup of the WordPress.org SVN repository after a
+# previous deploy script mistakenly committed the plugin to the repo root instead
+# of trunk/. Removes those stray root files and the bogus tags/1.3.6 (which was a
+# copy of the stale 1.3.5 trunk). Leaves trunk/, tags/ and assets/ untouched.
+# Safe to delete this workflow once the cleanup has run successfully.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Remove stray root files and bogus tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
+
+      - name: Clean up SVN repository
+        env:
+          SVN_URL: ${{ secrets.SVN_URL }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        run: |
+          set -e
+          AUTH="--username $SVN_USERNAME --password $SVN_PASSWORD --non-interactive --no-auth-cache"
+
+          # 1. Remove the incorrect tag (it is a copy of the stale 1.3.5 trunk).
+          svn delete $AUTH -m "Remove incorrect 1.3.6 tag (was a copy of 1.3.5 trunk)" \
+            "$SVN_URL/tags/1.3.6"
+
+          # 2. Remove the files mistakenly committed to the repo root by the old
+          #    deploy script. trunk/, tags/ and assets/ are intentionally NOT listed.
+          STRAY=".gitignore README.txt admin autoload.php bora_bora.php composer.json composer.lock deploy.sh generate-wp-icons.sh includes index.php languages public uninstall.php vendor"
+          TARGETS=""
+          for p in $STRAY; do TARGETS="$TARGETS $SVN_URL/$p"; done
+          svn delete $AUTH -m "Remove files mistakenly committed to repo root by old deploy script" $TARGETS


### PR DESCRIPTION
## 📋 Summary

The release-to-SVN deploy never actually published new versions. The custom script rsynced the plugin into the **root** of the SVN checkout instead of `trunk/`, so `trunk` kept serving the previous version and the release tag was created as a copy of that stale `trunk`. The 1.3.6 release surfaced this: `trunk` is still 1.3.5, `tags/1.3.6` contains 1.3.5, and the 1.3.6 files landed at the ignored repo root.

## 🔍 Key Changes

- ⚙️ **Replace the custom sync script with `10up/action-wordpress-plugin-deploy`** — the standard WordPress.org deploy. It commits the plugin to `trunk` and tags from `trunk`, with `SLUG: bora-bora` and the existing `SVN_USERNAME`/`SVN_PASSWORD` secrets.
- 🧹 **Add `.distignore`** so development/CI files (`.git`, `.github`, `deploy.sh`, `generate-wp-icons.sh`, `composer.*`) are not shipped to the directory.
- 🩹 **Add a one-off `workflow_dispatch` cleanup** that removes the stray files committed to the SVN repo root and the bogus `tags/1.3.6`, leaving `trunk/`, `tags/` and `assets/` untouched.

## 🎯 Impact

After merge: run the cleanup workflow once, then re-publish the 1.3.6 release so the 10up action deploys it correctly to `trunk` + `tags/1.3.6`. The live `assets/` (plugin icon) is preserved throughout.

> [!NOTE]
> The `svn-cleanup.yml` workflow is a one-off and can be deleted once it has run successfully.