### PR TITLE
Fix WordPress.org readme metadata (1.3.7)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,15 +2,15 @@
 Contributors: boraboraio
 Author: Bora Bora
 Donate link: https://bora-bora.io/
-Tags: community, membership, subscription, paywall, user access, monetization, discord
-Stable tag: 1.3.6
+Tags: community, membership, subscription, paywall, discord
+Stable tag: 1.3.7
 Requires PHP: 8.2
 Tested up to: 6.8
 Requires at least: 6.4
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Bora Bora helps you manage and monetize your online community. Protect content, manage memberships and connect your WordPress site to your Bora-Bora.io account — all in one simple plugin.
+Manage and monetize your online community — protect content, manage memberships, and connect your site to your Bora-Bora.io account.
 
 == Description ==
 
@@ -62,6 +62,9 @@ No, payments and subscriptions are managed securely through Bora-Bora.io. The pl
 Yes. Any post type that supports custom fields can be protected by role.
 
 == Changelog ==
+
+= 1.3.7 =
+* Fixed: readme metadata for WordPress.org — limited tags to 5 and shortened the description to the supported length
 
 = 1.3.6 =
 * Fixed: connecting a site to Bora Bora now completes on saving the API key — the companion user credentials are provisioned on save instead of on activation, so a fresh install connects in one step (no reactivation needed)

--- a/bora_bora.php
+++ b/bora_bora.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Bora Bora
  * Plugin URI:        https://bora-bora.io
  * Description:       Bora Bora offers a complete solution for managing your community, from the subscription to the management of the users and their access to the content
- * Version:           1.3.6
+ * Version:           1.3.7
  * Author:            Bora Bora
  * Author URI:        https://bora-bora.io/
  * License:           GPL-2.0+
@@ -28,7 +28,7 @@ if (!defined('WPINC')) {
 /**
  * Currently plugin version.
  */
-const BORABORAIO_VERSION = '1.3.6';
+const BORABORAIO_VERSION = '1.3.7';
 
 /**
  * The name of the Plugin


### PR DESCRIPTION
## 📋 Summary

The 1.3.6 import to WordPress.org raised two readme warnings: the tag list had 7 entries (`monetization` and `discord` were dropped; max is 5) and the short description exceeded the 150-character limit. Since tags can't be edited on an already-published version, this fixes the readme and ships as patch release `1.3.7`.

## 🔍 Key Changes

- 🏷️ Tags limited to 5: `community, membership, subscription, paywall, discord`.
- ✂️ Short description shortened to 134 characters.
- 🔖 Version bumped to `1.3.7` (header + `BORABORAIO_VERSION` + readme stable tag) with a changelog entry.

No code changes — metadata only.